### PR TITLE
Bounding box & scaling fix

### DIFF
--- a/bms_blender_plugin/__init__.py
+++ b/bms_blender_plugin/__init__.py
@@ -7,8 +7,8 @@ from bms_blender_plugin.ext.blender_dds_addon.directx.texconv import unload_texc
 
 bl_info = {
     "name": "Falcon BMS Plugin",
-    "author": "Benchmark Sims / richionizor & Spearhead",
-    "version": (0, 0, 202308301),
+    "author": "Benchmark Sims",
+    "version": (0, 0, 20250118),
     "blender": (3, 6, 0),
     "location": "File > Export",
     "description": "Export as Falcon BMS BML",

--- a/bms_blender_plugin/exporter/bml_output.py
+++ b/bms_blender_plugin/exporter/bml_output.py
@@ -31,18 +31,14 @@ def export_bml(context, lods, file_directory, file_prefix, export_settings: Expo
     start_time = datetime.datetime.now()
     print(f"Starting BML export at {start_time}\n")
 
-    # determine whether the current scene is set to imperial units, otherwise we have to scale our objects
-    scale_factor = 1
+    # blender uses meters as base unit, BMS works in feet
+    # note that unit system does not scale the model, it just changes the dimension units
+    scale_factor = 3.28084
 
-    if bpy.context.scene.unit_settings.system == "METRIC":
-        if bpy.context.scene.unit_settings.length_unit == "METERS":
-            scale_factor = 3.28084
-        elif bpy.context.scene.unit_settings.length_unit == "CENTIMETERS":
-            scale_factor = 3.28084 * 100
-        elif bpy.context.scene.unit_settings.length_unit == "MILLIMETERS":
-            scale_factor = 3.28084 * 1000
-    elif bpy.context.scene.unit_settings.length_unit == "INCHES":
-        scale_factor = 0.0833333
+    # apply the scale factor as set in scene->units->unit scale
+    # this factor does not scale the model, it scales the dimension units
+    # to get this reflected in the model, apply this on scale factor
+    scale_factor *= bpy.context.scene.unit_settings.scale_length
 
     print(f"unit scaling factor: {scale_factor}")
 
@@ -52,8 +48,18 @@ def export_bml(context, lods, file_directory, file_prefix, export_settings: Expo
     # try to find the bounding box - we take the first one we get
     for obj in context.scene.objects:
         if get_bml_type(obj) == BlenderNodeType.BBOX:
-            bounding_box_1_coords = obj.matrix_world @ obj.data.vertices[0].co
-            bounding_box_2_coords = obj.matrix_world @ obj.data.vertices[5].co
+            max_x, min_x, max_y, min_y, max_z, min_z = (0,)*6
+            # find the min and max coordinates of the 8 vertices
+            for corner in obj.data.vertices:
+                max_x = max(corner.co.x, max_x)
+                min_x = min(corner.co.x, min_x)
+                max_y = max(corner.co.y, max_y)
+                min_y = min(corner.co.y, min_y)
+                max_z = max(corner.co.z, max_z)
+                min_z = min(corner.co.z, min_z)
+
+            bounding_box_1_coords = Vector((max_x, max_y, max_z))
+            bounding_box_2_coords = Vector((min_x, min_y, min_z))
 
             bounding_box_1_coords *= scale_factor
             bounding_box_2_coords *= scale_factor
@@ -90,6 +96,7 @@ def export_bml(context, lods, file_directory, file_prefix, export_settings: Expo
             file_prefix,
             bounding_box_1_coords,
             bounding_box_2_coords,
+            scale_factor,
             number_of_texture_sets,
             get_slots(context.scene),
             lods

--- a/bms_blender_plugin/exporter/export_parent_dat.py
+++ b/bms_blender_plugin/exporter/export_parent_dat.py
@@ -13,8 +13,9 @@ from bms_blender_plugin.common.util import (
 
 def get_highest_switch_and_dof_number(objs):
     """Returns the highest values of dofs and switches. Required for the Parent.dat"""
-    highest_switch_number = -1
-    highest_dof_number = -1
+    # default value 0 to prevent editor crashing
+    highest_switch_number = 0
+    highest_dof_number = 0
 
     for obj in objs:
         if len(obj.children) > 0:
@@ -46,6 +47,7 @@ def export_parent_dat(
     file_prefix: str,
     bounding_box_1_coords,
     bounding_box_2_coords,
+    scale_factor,
     number_of_texture_sets,
     slot_list,
     lod_list,
@@ -65,6 +67,8 @@ def export_parent_dat(
     bounding_sphere_center, bounding_sphere_radius = get_bounding_sphere(
         context.scene.objects
     )
+    
+    bounding_sphere_radius *= scale_factor
 
     with open(parent_dat_filepath, "w") as parent_dat_file:
         str_output = (

--- a/bms_blender_plugin/ui_tools/operators/create_bounding_box_operator.py
+++ b/bms_blender_plugin/ui_tools/operators/create_bounding_box_operator.py
@@ -67,6 +67,9 @@ def group_bounding_box():
         0.0,
     ] * 3
     for obj in bpy.context.visible_objects:
+        # exclude eg camera, lights
+        if obj.type != "MESH":
+            continue
         for vertex in obj.bound_box:
             v_world = obj.matrix_world @ mathutils.Vector(
                 (vertex[0], vertex[1], vertex[2])


### PR DESCRIPTION
- blender uses meter internally so scale using meter-to-feet factor
- apply scaling factor as set in set in scene->units->unit scale
- bounding box uses min/max coordinates of mesh entities only and excludes eg camera
- radius in parant.dat is correctly scaled
- default nr of switches and dofs set to zero in parant.dat to prevent editor crashes