### PR TITLE
Fix Panel Register Dependency

### DIFF
--- a/bms_blender_plugin/__init__.py
+++ b/bms_blender_plugin/__init__.py
@@ -60,7 +60,7 @@ def register():
         if module_name in sys.modules and hasattr(sys.modules[module_name], "register"):
             try:
                 sys.modules[module_name].register()
-            except (KeyError, ValueError): # open template file or re-enble may causes this
+            except ValueError: # open template file or re-enble may causes this
                 pass
 
 

--- a/bms_blender_plugin/__init__.py
+++ b/bms_blender_plugin/__init__.py
@@ -60,7 +60,7 @@ def register():
         if module_name in sys.modules and hasattr(sys.modules[module_name], "register"):
             try:
                 sys.modules[module_name].register()
-            except ValueError: # open template file or re-enble may causes this
+            except ValueError:  # open template file may cause this problem
                 pass
 
 

--- a/bms_blender_plugin/__init__.py
+++ b/bms_blender_plugin/__init__.py
@@ -28,7 +28,7 @@ addon_dir = os.path.dirname(__file__)
 py_paths = [
     os.path.join(root, f)
     for root, dirs, files in os.walk(addon_dir)
-    for f in files
+    for f in sorted(files)
     if f.endswith(".py") and f != "__init__.py" and f != "test.py"
 ]
 
@@ -60,7 +60,7 @@ def register():
         if module_name in sys.modules and hasattr(sys.modules[module_name], "register"):
             try:
                 sys.modules[module_name].register()
-            except ValueError:  # open template file may cause this problem
+            except (KeyError, ValueError): # open template file or re-enble may causes this
                 pass
 
 


### PR DESCRIPTION
On MacOS there is no guarantee to get the file list back sorted like Windows. You can get in any order.

The MaterialSetsPanel requires the LodAndMaterialSetsPanel to be registered first. The file lod_and_material_sets_panel.py nicely delegates this to the LODPanel (in lod_panel.py) However this dependency is not properly enforced. On Windows the os.walk implementation seems to nicely sort the files already, however this is NOT the case on macOS and you get whatever order of these files. Since the current implementation seems to rely on the Windows platform which does the sorting for you, to be platform independent we must sort the list of files from os.walk(). This PR will make the blender plugin work on MacOS and I have tested on Sonoma 14.7.1