### PR TITLE
#28, Fix Hotspot coordinate translations.

### DIFF
--- a/bms_blender_plugin/common/coordinates.py
+++ b/bms_blender_plugin/common/coordinates.py
@@ -3,6 +3,9 @@ from mathutils import Vector, Matrix, Quaternion, Euler
 # Define the matrices here
 BMS_SPACE_MATRIX = Matrix(((1, 0, 0, 0), (0, 0, 1, 0), (0, 1, 0, 0), (0, 0, 0, 1)))
 BMS_SPACE_MATRIX_INV = BMS_SPACE_MATRIX.inverted_safe()
+""" Hotpots use an x=rearwards, y=left, z=up coordinate system, whereas blender uses an x=right, y=forward, z=up 
+coordinate system. The following transformation matrix will output a vector [-blender_y, -blender_x, blender_z] which 
+from our blender vector definitions is [-forward, -right, up] = [rearwards, left, up]"""
 BMS_HOTSPOT_MATRIX = Matrix(((0, -1, 0), (-1, 0, 0), (0, 0, 1)))
 
 def to_bms_coords(data, space_mat=BMS_SPACE_MATRIX, space_mat_inv=BMS_SPACE_MATRIX_INV):

--- a/bms_blender_plugin/common/coordinates.py
+++ b/bms_blender_plugin/common/coordinates.py
@@ -3,6 +3,7 @@ from mathutils import Vector, Matrix, Quaternion, Euler
 # Define the matrices here
 BMS_SPACE_MATRIX = Matrix(((1, 0, 0, 0), (0, 0, 1, 0), (0, 1, 0, 0), (0, 0, 0, 1)))
 BMS_SPACE_MATRIX_INV = BMS_SPACE_MATRIX.inverted_safe()
+BMS_HOTSPOT_MATRIX = Matrix(((0, -1, 0), (-1, 0, 0), (0, 0, 1)))
 
 def to_bms_coords(data, space_mat=BMS_SPACE_MATRIX, space_mat_inv=BMS_SPACE_MATRIX_INV):
     """Transforms from Blender space to BMS space (-Z forward, Y up)."""

--- a/bms_blender_plugin/common/hotspot.py
+++ b/bms_blender_plugin/common/hotspot.py
@@ -1,12 +1,9 @@
 from enum import Enum
-from mathutils import Vector
-from bms_blender_plugin.common.coordinates import to_bms_coords
-
+from mathutils import Vector, Matrix
 
 class MouseButton(int, Enum):
     LEFT_CLICK = 1
     RIGHT_CLICK = 2
-
 
 class ButtonType(str, Enum):
     SWITCH = ""
@@ -23,6 +20,8 @@ class Callback:
 
 class Hotspot:
     """Represents a user-clickable hotspot in the 3d pit. Used in 3dButtons.dat"""
+    """Translations defines elsewhere are not compatible with the hotspots and 3dButton.dat file. This translation works."""
+    BMS_HOTSPOT_MATRIX = Matrix(((0, -1, 0), (-1, 0, 0), (0, 0, 1)))
 
     def __init__(
         self,
@@ -36,23 +35,27 @@ class Hotspot:
         button_type: ButtonType,
     ):
         self.callback_id = callback_id
-        self.x = x
-        self.y = y
-        self.z = z
+        self.blend_x = x
+        self.blend_y = y
+        self.blend_z = z
         self.size = size
         self.sound_id = sound_id
         self.mouse_button = mouse_button
         self.button_type = button_type
+        self.blender_coords = Vector((self.blend_x, self.blend_y, self.blend_z))
+        self.bms_coords = self.to_bms_hotspot_coords(self.blender_coords)
+
+    def to_bms_hotspot_coords(self, data, transformation=BMS_HOTSPOT_MATRIX):
+        """Transforms applied elsewhere do not seem to be compatible for hotspots (maybe other vectors as well?)
+        Without robust testing the safest way to fix this is within the hotspot class."""
+        return data @ transformation
 
     def __str__(self):
         """"Format according to 3dButtons.dat.
         BMS should have no problems reading different amounts of spaces, but it looks prettier..."""
-        # Use consistent coordinate transformation utility
-        bms_coords = to_bms_coords(Vector((self.x, self.y, self.z)))
-
         output = f"{self.callback_id.ljust(29 ,' ')}"
         output += "{:{w}.{p}f}{:{w}.{p}f}{:{w}.{p}f}".format(
-            round(bms_coords.x, 6), round(bms_coords.y, 6), round(bms_coords.z, 6), w=12, p=6
+            round(self.bms_coords.x, 6), round(self.bms_coords.y, 6), round(self.bms_coords.z, 6), w=12, p=6
         )
         output += f"{' ':<4}{self.size}{' ':<4}{self.sound_id}{' ':<4}{self.mouse_button}"
 

--- a/bms_blender_plugin/common/hotspot.py
+++ b/bms_blender_plugin/common/hotspot.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from mathutils import Vector, Matrix
+from mathutils import Vector
 from bms_blender_plugin.common.coordinates import BMS_HOTSPOT_MATRIX
 
 

--- a/bms_blender_plugin/common/hotspot.py
+++ b/bms_blender_plugin/common/hotspot.py
@@ -1,5 +1,7 @@
 from enum import Enum
 from mathutils import Vector, Matrix
+from bms_blender_plugin.common.coordinates import BMS_HOTSPOT_MATRIX
+
 
 class MouseButton(int, Enum):
     LEFT_CLICK = 1
@@ -21,7 +23,6 @@ class Callback:
 class Hotspot:
     """Represents a user-clickable hotspot in the 3d pit. Used in 3dButtons.dat"""
     """Translations defines elsewhere are not compatible with the hotspots and 3dButton.dat file. This translation works."""
-    BMS_HOTSPOT_MATRIX = Matrix(((0, -1, 0), (-1, 0, 0), (0, 0, 1)))
 
     def __init__(
         self,

--- a/bms_blender_plugin/common/hotspot.py
+++ b/bms_blender_plugin/common/hotspot.py
@@ -22,7 +22,6 @@ class Callback:
 
 class Hotspot:
     """Represents a user-clickable hotspot in the 3d pit. Used in 3dButtons.dat"""
-    """Translations defines elsewhere are not compatible with the hotspots and 3dButton.dat file. This translation works."""
 
     def __init__(
         self,

--- a/bms_blender_plugin/exporter/parser.py
+++ b/bms_blender_plugin/exporter/parser.py
@@ -284,7 +284,7 @@ def parse_hotspot(obj, hotspots: dict):
     Ignores all duplicate callback names."""
     print(f"{obj.name} is a HOTSPOT")
 
-    location = to_bms_coords(obj.matrix_world.translation)
+    location = obj.matrix_world.translation
     for callback in obj.bml_hotspot_callbacks:
         if callback.callback_name not in hotspots.keys():
             hotspot = Hotspot(

--- a/docs/Manual/MANUAL.md
+++ b/docs/Manual/MANUAL.md
@@ -160,8 +160,9 @@ Although the BML Model format can act on its own, in order to get its full poten
 - **BML objects** - Up to 6 Levels of Detail. Naming convention is Model_0.bml (Highest level of detail) through Model_6.bml (lowest level of detail).
 - **3dButtons.dat** - Lists all Hotspots and their callbacks.
 
-All these files go into a parent folder, indexed by a number. All of Falcon's parent folders will be in ```<Your Falcon BMS Directory>/Data/Terrdata/Objects/Models```.
+With the exception of 3dButtons.dat, all these files go into a parent folder, indexed by a number. All of Falcon's parent folders will be in ```<Your Falcon BMS Directory>/Data/Terrdata/Objects/Models```.
 
+3dButtons.dat should be placed into ```<Your Falcon BMS Directory>/Data/Art/CkptArt/<Target Aircraft>```
 
 ### 3.3. Object Limitations
 Recommended Maximum Triangle count and Draw calls:


### PR DESCRIPTION
1. Removed translation from hotspot definition in the parser as this translation is invalid for hotspots.
2. Added the correct translation matrix to the hotspot class. 
3. Definition of blender and bms coordinate vectors are calculated on instance creation to facilitate future unit testing.