### PR TITLE
#39 - BML Slot indexing fix

### DIFF
--- a/bms_blender_plugin/ui_tools/operators/__init__.py
+++ b/bms_blender_plugin/ui_tools/operators/__init__.py
@@ -60,10 +60,10 @@ def register_blender_properties():
     # Slots
     bpy.types.Object.bml_slot_number = bpy.props.IntProperty(
         name="Slot number",
-        description="Slot number (1-13)",
-        default=1,
-        min=1,
-        max=13,
+        description="Slot number (0-20)",
+        default=0,
+        min=0,
+        max=20,
         update=update_slot_number,
     )
 

--- a/bms_blender_plugin/ui_tools/operators/slot_operators.py
+++ b/bms_blender_plugin/ui_tools/operators/slot_operators.py
@@ -13,7 +13,7 @@ class CreateSlot(Operator):
 
     # noinspection PyMethodMayBeStatic
     def execute(self, context):
-        slot_object = bpy.data.objects.new("Slot #1", None)
+        slot_object = bpy.data.objects.new("Slot #0", None)
         slot_object.bml_type = str(BlenderNodeType.SLOT)
         slot_object.empty_display_type = "IMAGE"
         slot_object.empty_display_size = 2


### PR DESCRIPTION
- Updated slot logic, range from 0 -> 20. 

- Hard limit of 13 seemed arbitrary and unenforced given that A10 model already has 15 slots.

- May require users to re-define slots.

Tested working on arbitrary test cube
https://i.postimg.cc/mrbZnK50/Slot-indexing-fixed.png